### PR TITLE
Rough start/stop scripts

### DIFF
--- a/kill_em_all.sh
+++ b/kill_em_all.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+rabbitmqctl stop
+
+printf "Killing all celery workers\n"
+ps auxww | grep 'celery worker' | awk '{print $2}' | xargs kill -9
+
+printf "Killing all flask server instances\n"
+ps auxww | grep 'flask run' | awk '{print $2}' | xargs kill

--- a/start_everything.sh
+++ b/start_everything.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# make the logs directory and ignore the error if it already exists
+mkdir logs 2> /dev/null
+printf "\nprocess logs can be found in the 'logs' directory\n"
+
+# start rabbitmq & flask
+rabbitmq-server &> logs/rabbitmq.log &
+printf "rabbitmq-server started\n"
+pipenv run celery worker -A app -l INFO &> logs/celery.log &
+printf "celery worker instance started\n"
+
+# set environment variables for flask
+export FLASK_ENV=development
+pipenv run flask run &> logs/flask.log &
+printf "flask started\n"
+
+printf "Run ./kill_em_all.sh to shut everything down.\n"


### PR DESCRIPTION
These scripts start up/shut down rabbitmq, celery, and flask.
Hopefully they are easier than remembering the commands for each function.

Two potential issues:
1. rabbitmq logs aren't attached to the main process - they're in `/usr/local/var/log/rabbitmq/` on mac
2. There are more graceful ways of shutting down flask & celery. I'm just killing the processes here.